### PR TITLE
fix #4 - memory leak & support multiple uses of v-esc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import vueEsc from './vue-esc'
 const plugin = {
   install (Vue) {
     Vue.directive('esc', vueEsc)
+    document.addEventListener('keyup', vueEsc.onEvent)
   }
 }
 

--- a/src/vue-esc.js
+++ b/src/vue-esc.js
@@ -1,14 +1,13 @@
 const vueEsc = {}
 
+vueEsc.cb = new Map() // key: HTMLElement, value: callback
+
 vueEsc.onEvent = function (event) {
   if (event.keyCode === 27) {
-    vueEsc.cb && vueEsc.cb(event)
+    for (const [element, cb] of vueEsc.cb.entries()) {
+      cb && cb.call(element, event)
+    }
   }
-}
-
-vueEsc.bind = function (el) {
-  vueEsc.onEventBound = vueEsc.onEvent.bind({ el })
-  document.addEventListener('keyup', vueEsc.onEventBound)
 }
 
 vueEsc.update = function (el, binding) {
@@ -16,11 +15,11 @@ vueEsc.update = function (el, binding) {
     throw new Error('Argument must be a function')
   }
 
-  vueEsc.cb = binding.value
+  vueEsc.cb.set(el, binding.value)
 }
 
-vueEsc.unbind = function () {
-  document.removeEventListener('keyup', vueEsc.onEventBound)
+vueEsc.unbind = function (el) {
+  vueEsc.cb.delete(el)
 }
 
 export default vueEsc

--- a/test/vue-esc.spec.js
+++ b/test/vue-esc.spec.js
@@ -76,6 +76,26 @@ describe('vue-esc => directive', () => {
     })
   })
 
+  describe('onEvent', () => {
+    const message = 'it calls the callback with `this` set to the HTML element'
+
+    it(message, () => {
+      const event = {
+        keyCode: 27
+      }
+
+      const cb1 = jest.fn()
+
+      vueEsc.cb.set(div, cb1)
+
+      vueEsc.onEvent(event)
+      expect(cb1).toHaveBeenCalledWith(event)
+
+      const cb1ValueOfThis = cb1.mock.instances[0]
+      expect(cb1ValueOfThis).toBe(div)
+    })
+  })
+
   describe('unbind', () => {
     it('unregisters the callback', () => {
       const div2 = document.createElement('div')

--- a/test/vue-esc.spec.js
+++ b/test/vue-esc.spec.js
@@ -96,6 +96,20 @@ describe('vue-esc => directive', () => {
     })
   })
 
+  describe('onEvent', () => {
+    it('ignores events which are not for the ESC key', () => {
+      const event = {
+        keyCode: 0
+      }
+
+      const cb1 = jest.fn()
+      vueEsc.cb.set(div, cb1)
+
+      vueEsc.onEvent(event)
+      expect(cb1).not.toHaveBeenCalledWith(event)
+    })
+  })
+
   describe('unbind', () => {
     it('unregisters the callback', () => {
       const div2 = document.createElement('div')


### PR DESCRIPTION
There is now only one callback listening on `window.document` and this callback is in charge of calling the vue component callback defined with the `v-esc` directive.

any time the value of the `v-esc` changes, we just override the callback that was previously registered without requiring to call `document.removeEventListener()`